### PR TITLE
feat: support ObjectPattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "acorn": "^7.1.0",
     "acorn-bigint": "^0.4.0",
     "is-buffer": "^2.0.4",
-    "iso-error": "^3.1.1",
     "unpartial": "^0.6.3"
   },
   "devDependencies": {

--- a/src/tersify.spec.ts
+++ b/src/tersify.spec.ts
@@ -900,6 +900,25 @@ describe('function', () => {
     const subject = function spread(x) { console.info(...x) }
     expect(tersify(subject)).toBe(`fn spread(x) { console.info(...x) }`)
   })
+  test('argument destructuring', () => {
+    const subject = function ({ a, b, c }) { }
+    expect(tersify(subject)).toBe(`fn({ a, b, c }) {}`)
+    expect(tersify(subject, { maxLength: 18 })).toBe(`fn({ a, b, c }) {}`)
+    expect(tersify(subject, { maxLength: 17 })).toBe(`fn({ a, b,...) {}`)
+    expect(tersify(subject, { maxLength: 16 })).toBe(`fn({ a, b...) {}`)
+    expect(tersify(subject, { maxLength: 15 })).toBe(`fn({ a, ...) {}`)
+    expect(tersify(subject, { maxLength: 14 })).toBe(`fn({ a,...) {}`)
+    expect(tersify(subject, { maxLength: 13 })).toBe(`fn({ a...) {}`)
+    expect(tersify(subject, { maxLength: 12 })).toBe(`fn({ ...) {}`)
+    expect(tersify(subject, { maxLength: 11 })).toBe(`fn({ ..) {}`)
+    expect(tersify(subject, { maxLength: 10 })).toBe(`fn({ .) {}`)
+    expect(tersify(subject, { maxLength: 9 })).toBe(`fn({ ....`)
+  })
+
+  test('argument destructuring with default assignment', () => {
+    const subject = function ({ a = { b: 1 } }) { }
+    expect(tersify(subject)).toBe(`fn({ a = { b: 1 } }) {}`)
+  })
 })
 
 describe('arrow function', () => {
@@ -1463,6 +1482,49 @@ describe('arrow function', () => {
   test('raw will skip tersify() method', () => {
     expect(tersify(tersible((x, y) => x + y, () => 'x + y'), { raw: true })).toBe('(x, y) => x + y')
     expect(tersify(tersible(function (x, y) { return x + y }, () => 'x + y'), { raw: true })).toBe('function(x, y) { return x + y }')
+  })
+
+  test('argument destructuring', () => {
+    const subject = ({ a, b, c }) => true
+    expect(tersify(subject)).toBe(`({ a, b, c }) => true`)
+    expect(tersify(subject, { maxLength: 21 })).toBe(`({ a, b, c }) => true`)
+    expect(tersify(subject, { maxLength: 20 })).toBe(`({ a, b,...) => true`)
+    expect(tersify(subject, { maxLength: 19 })).toBe(`({ a, b...) => true`)
+    expect(tersify(subject, { maxLength: 18 })).toBe(`({ a, ...) => true`)
+    expect(tersify(subject, { maxLength: 17 })).toBe(`({ a,...) => true`)
+    expect(tersify(subject, { maxLength: 16 })).toBe(`({ a...) => true`)
+    expect(tersify(subject, { maxLength: 15 })).toBe(`({ ...) => true`)
+    expect(tersify(subject, { maxLength: 14 })).toBe(`({ ..) => true`)
+    expect(tersify(subject, { maxLength: 13 })).toBe(`({ .) => true`)
+    expect(tersify(subject, { maxLength: 12 })).toBe(`({.) => true`)
+    expect(tersify(subject, { maxLength: 11 })).toBe(`(.) => true`)
+    expect(tersify(subject, { maxLength: 10 })).toBe(`(.) => tr.`)
+    expect(tersify(subject, { maxLength: 9 })).toBe(`(.) =>...`)
+    expect(tersify(subject, { maxLength: 8 })).toBe(`(.) =...`)
+    expect(tersify(subject, { maxLength: 7 })).toBe(`(.) ...`)
+    expect(tersify(subject, { maxLength: 6 })).toBe(`(.)...`)
+    expect(tersify(subject, { maxLength: 5 })).toBe(`(....`)
+    expect(tersify(subject, { maxLength: 4 })).toBe(`(...`)
+    expect(tersify(subject, { maxLength: 3 })).toBe(`(..`)
+    expect(tersify(subject, { maxLength: 2 })).toBe(`(.`)
+    expect(tersify(subject, { maxLength: 1 })).toBe(`.`)
+    expect(tersify(subject, { maxLength: 0 })).toBe(``)
+  })
+
+  test('argument destructuring with default assignment', () => {
+    const subject = ({ a = { b: 1 } }) => true
+    expect(tersify(subject)).toBe(`({ a = { b: 1 } }) => true`)
+    expect(tersify(subject, { maxLength: 26 })).toBe(`({ a = { b: 1 } }) => true`)
+    expect(tersify(subject, { maxLength: 25 })).toBe(`({ a = { b: 1...) => true`)
+    expect(tersify(subject, { maxLength: 24 })).toBe(`({ a = { b: ...) => true`)
+    expect(tersify(subject, { maxLength: 23 })).toBe(`({ a = { b:...) => true`)
+    expect(tersify(subject, { maxLength: 22 })).toBe(`({ a = { b...) => true`)
+    expect(tersify(subject, { maxLength: 21 })).toBe(`({ a = { ...) => true`)
+    expect(tersify(subject, { maxLength: 20 })).toBe(`({ a = {...) => true`)
+    expect(tersify(subject, { maxLength: 19 })).toBe(`({ a = ...) => true`)
+    expect(tersify(subject, { maxLength: 18 })).toBe(`({ a =...) => true`)
+    expect(tersify(subject, { maxLength: 17 })).toBe(`({ a ...) => true`)
+    expect(tersify(subject, { maxLength: 16 })).toBe(`({ a...) => true`)
   })
 })
 

--- a/src/tersifyAcorn/AcornTypes.ts
+++ b/src/tersifyAcorn/AcornTypes.ts
@@ -9,7 +9,8 @@ export type AcornNode = IdentifierNode | LiteralNode | CallExpressionNode |
   SwitchStatementNode | SwitchCaseNode | ForInStatementNode | ForOfStatementNode |
   ObjectExpressionNode | PropertyNode | YieldExpressionNode | AwaitExpressionNode |
   ArrayExpression | ThrowStatementNode | TryStatementNode | CatchClauseNode |
-  ThisExpressionNode | ClassExpressionNode | ClassBodyNode | MethodDefinitionNode | SpreadElementNode
+  ThisExpressionNode | ClassExpressionNode | ClassBodyNode | MethodDefinitionNode | SpreadElementNode |
+  ObjectPatternNode
 
 export type AcornNodeBase = {
   start: number,
@@ -85,7 +86,7 @@ export type ArrowFunctionExpressionNode = AcornNodeBase & {
   expression: boolean,
   generator: boolean,
   async: boolean,
-  params: IdentifierNode[],
+  params: Array<IdentifierNode | ObjectPatternNode>,
   body: AcornNode
 }
 
@@ -311,4 +312,9 @@ export type MethodDefinitionNode = AcornNodeBase & {
 export type SpreadElementNode = AcornNodeBase & {
   type: 'SpreadElement',
   argument: IdentifierNode
+}
+
+export type ObjectPatternNode = AcornNodeBase & {
+  type: 'ObjectPattern',
+  properties: PropertyNode[]
 }

--- a/src/tersifyAcorn/FailedToParse.ts
+++ b/src/tersifyAcorn/FailedToParse.ts
@@ -1,9 +1,0 @@
-import { IsoError } from 'iso-error'
-import { AcornNode } from './AcornTypes'
-
-// istanbul ignore next
-export class FailedToParse extends IsoError {
-  constructor(public nodeType: string, public node: AcornNode) {
-    super(`${nodeType}: ${JSON.stringify(node, undefined, 2)}`)
-  }
-}

--- a/src/tersifyAcorn/tersifyAcron.ts
+++ b/src/tersifyAcorn/tersifyAcron.ts
@@ -1,11 +1,10 @@
 
 import { Parser } from 'acorn';
 import bigInt from 'acorn-bigint';
-import { AcornNode, ArrowFunctionExpressionNode, AssignmentExpressionNode, AssignmentPatternNode, BinaryExpressionNode, BlockStatementNode, BreakStatementNode, CallExpressionNode, ConditionalExpressionNode, ContinueStatementNode, DoWhileStatementNode, ExpressionStatementNode, ForInStatementNode, ForOfStatementNode, ForStatementNode, FunctionExpressionNode, IdentifierNode, IfStatementNode, LabeledStatementNode, LiteralNode, LogicalExpressionNode, MemberExpressionNode, NewExpressionNode, RestElementNode, ReturnStatementNode, SwitchCaseNode, SwitchStatementNode, SymbolForNode, UnaryExpressionNode, UpdateExpressionNode, VariableDeclarationNode, VariableDeclaratorNode, WhileStatementNode, ObjectExpressionNode, PropertyNode, YieldExpressionNode, AwaitExpressionNode, ArrayExpression, ThrowStatementNode, TryStatementNode, CatchClauseNode, ThisExpressionNode, FunctionDeclarationNode, ClassExpressionNode, ClassBodyNode, MethodDefinitionNode, SpreadElementNode } from './AcornTypes';
-import { isHigherOperatorOrder } from './isHigherBinaryOperatorOrder';
-import { TersifyContext } from '../typesInternal';
 import { trim } from '../trim';
-import { FailedToParse } from './FailedToParse';
+import { TersifyContext } from '../typesInternal';
+import { AcornNode, ArrayExpression, ArrowFunctionExpressionNode, AssignmentExpressionNode, AssignmentPatternNode, AwaitExpressionNode, BinaryExpressionNode, BlockStatementNode, BreakStatementNode, CallExpressionNode, CatchClauseNode, ClassBodyNode, ClassExpressionNode, ConditionalExpressionNode, ContinueStatementNode, DoWhileStatementNode, ExpressionStatementNode, ForInStatementNode, ForOfStatementNode, ForStatementNode, FunctionDeclarationNode, FunctionExpressionNode, IdentifierNode, IfStatementNode, LabeledStatementNode, LiteralNode, LogicalExpressionNode, MemberExpressionNode, MethodDefinitionNode, NewExpressionNode, ObjectExpressionNode, ObjectPatternNode, PropertyNode, RestElementNode, ReturnStatementNode, SpreadElementNode, SwitchCaseNode, SwitchStatementNode, SymbolForNode, ThisExpressionNode, ThrowStatementNode, TryStatementNode, UnaryExpressionNode, UpdateExpressionNode, VariableDeclarationNode, VariableDeclaratorNode, WhileStatementNode, YieldExpressionNode } from './AcornTypes';
+import { isHigherOperatorOrder } from './isHigherBinaryOperatorOrder';
 
 export function tersifyAcorn(context: TersifyContext, value: any, length: number) {
   const parser = Parser.extend(bigInt)
@@ -112,9 +111,15 @@ function tersifyAcornNode(context: TersifyContext, node: AcornNode | null, lengt
       return tersifyClassExpression(context, node, length)
     case 'MethodDefinition':
       return tersifyMethodDefinition(context, node, length)
-    default:
-      // istanbul ignore next
-      throw new FailedToParse((node as any).type, node)
+    case 'ObjectPattern':
+      return tersifyObjectPattern(context, node, length)
+    default: {
+      const nodeType = (node as any).type
+      console.warn(`tersify received unsupported type: ${nodeType}. Please open an issue at https://github.com/unional/tersify/issues
+node detail:
+${JSON.stringify(node, undefined, 2)}`)
+      return `<unsupported: ${nodeType}>`
+    }
   }
 }
 
@@ -159,6 +164,10 @@ function tersifyPropertyNode(context: TersifyContext, node: PropertyNode, length
     const params = tersifyFunctionParams(context, valueNode.params)
     const body = tersifyFunctionBody(context, valueNode.body)
     return `${async}${generator}${key}${params} ${body}`
+  }
+
+  if (valueNode.type === 'AssignmentPattern') {
+    return tersifyAcornNode(context, valueNode, length)
   }
 
   const value = tersifyAcornNode(context, valueNode, length)
@@ -365,55 +374,45 @@ function tersifyArrowExpressionNode(context: TersifyContext, node: ArrowFunction
   const async = node.async ? 'async ' : ''
   const generator = node.generator ? '*' : ''
   const arrow = ` => `
-  const declarationLen = async.length + generator.length + arrow.length
+  const skipParamParen = node.params.length === 1 && node.params[0].type !== 'ObjectPattern'
 
-  let params = node.params.length > 0 ? tersifyFunctionParams(context, node.params) : '()'
-  const paramsContent = params.slice(1, params.length - 1)
-
-  if (node.params.length === 1) {
-    params = paramsContent
-  }
-  const minParam = paramsContent.length <= 3 ?
-    params :
-    node.params.length > 1 ?
-      `(${trim(context, paramsContent, 3)})` :
-      trim(context, paramsContent, 3)
-
-  const minPrebodyLen = declarationLen + minParam.length
-  const prebodyLen = declarationLen + params.length
+  const paramsBody = tersifyParamsBody(context, node.params)
+  const params = skipParamParen ? paramsBody : `(${paramsBody})`
   const singleBodyNode = getSingleStatementBodyNode(context, node.body)
   let body = singleBodyNode ?
     tersifyArrowBodyAsSingleStatement(context, singleBodyNode) :
     tersifyFunctionBody(context, node.body)
 
-  if (singleBodyNode && singleBodyNode.type === 'ObjectExpression') {
+  const isSingleBodyObjectExpression = singleBodyNode && singleBodyNode.type === 'ObjectExpression'
+  if (isSingleBodyObjectExpression) {
     body = `(${body})`
   }
-  if (minPrebodyLen + body.length > length) {
-    if (singleBodyNode) {
-      const bodyContent = trim(context, body, length - minPrebodyLen)
-      const result = `${async}${generator}${minParam}${arrow}${bodyContent.length === 0 ?
-        '{}' :
-        singleBodyNode.type === 'ObjectExpression' ?
-          `(${bodyContent})` :
-          bodyContent}`
-      return result.length > length ? trim(context, result, length) : result
-    }
-    else {
-      const paramAndSpaceLen = 2 // '{ ' or ' }'
-      const bodyContent = trim(context, body.slice(2, body.length - paramAndSpaceLen), length - minPrebodyLen - paramAndSpaceLen * 2)
-      const result = `${async}${generator}${minParam}${arrow}${bodyContent.length === 0 ? '{}' : `{ ${bodyContent} }`}`
-      return result.length > length ? trim(context, result, length) : result
-    }
-  }
-  else if (prebodyLen + body.length > length) {
-    if (node.params.length === 1) {
-      return `${async}${generator}${trim(context, paramsContent, length - body.length - declarationLen)}${arrow}${body}`
-    }
-    return `${async}${generator}(${trim(context, paramsContent, length - body.length - declarationLen - 2)})${arrow}${body}`
+
+  if (async.length + generator.length + params.length + arrow.length + body.length <= length) {
+    return `${async}${generator}${params}${arrow}${body}`
   }
   else {
-    return `${async}${generator}${params}${arrow}${body}`
+    const lenAvailForParams = Math.max(skipParamParen ? 1 : 3, length - (async.length + generator.length + arrow.length + body.length))
+    const trimmedParams = skipParamParen ?
+      trim(context, paramsBody, lenAvailForParams) :
+      `(${trim(context, paramsBody, lenAvailForParams - 2)})`
+    if (async.length + generator.length + lenAvailForParams + arrow.length + body.length <= length) {
+      return `${async}${generator}${trimmedParams}${arrow}${body}`
+    }
+    else {
+      const minBodyLen = 3
+      const wrapLen = isSingleBodyObjectExpression ?
+        `({  })`.length :
+        singleBodyNode ? 0 : `{  }`.length
+      const lenAvailForBody = Math.max(minBodyLen, length - (async.length + generator.length + trimmedParams.length + arrow.length + wrapLen))
+      const trimmedBody = isSingleBodyObjectExpression ?
+        `({ ${trim(context, body.slice(2, body.length - 2), lenAvailForBody - 4)} })` :
+        singleBodyNode ?
+          trim(context, body, lenAvailForBody) :
+          `{ ${trim(context, body.slice(2, body.length - 1), lenAvailForBody)} }`
+
+      return trim(context, `${async}${generator}${trimmedParams}${arrow}${trimmedBody}`, length)
+    }
   }
 }
 
@@ -461,6 +460,13 @@ function isSymbolForNode(node: CallExpressionNode): node is SymbolForNode {
 
 }
 
+function tersifyParamsBody(context: TersifyContext, params: Array<IdentifierNode | LiteralNode | ObjectPatternNode>) {
+  return params.reduce((p, v) => {
+    p.push(tersifyAcornNode(context, v, Infinity))
+    return p
+  }, [] as string[]).join(', ')
+}
+
 function tersifyFunctionExpressionNode(context: TersifyContext, node: FunctionExpressionNode | FunctionDeclarationNode, length: number) {
   const token = context.raw ? `function` : 'fn'
   const async = node.async ? 'async ' : ''
@@ -500,12 +506,8 @@ function tersifyFunctionExpressionNode(context: TersifyContext, node: FunctionEx
   }
 }
 
-function tersifyFunctionParams(context: TersifyContext, params: (IdentifierNode | LiteralNode)[]) {
-  const result = params.reduce((p, v) => {
-    p.push(tersifyAcornNode(context, v, Infinity))
-    return p
-  }, [] as string[])
-  return `(${result.join(', ')})`
+function tersifyFunctionParams(context: TersifyContext, params: (IdentifierNode | LiteralNode | ObjectPatternNode)[]) {
+  return `(${tersifyParamsBody(context, params)})`
 }
 
 function tersifyFunctionBody(context: TersifyContext, value: AcornNode) {
@@ -584,4 +586,8 @@ function tersifyMethodDefinition(context: TersifyContext, node: MethodDefinition
   else {
     return trim(context, `${staticStr}${async}${generator}${id}${params}${space}${body}`, length)
   }
+}
+
+function tersifyObjectPattern(context: TersifyContext, node: ObjectPatternNode, length: number) {
+  return `${trim(context, `{ ${node.properties.map(p => tersifyAcornNode(context, p, length)).join(', ')} }`, length - 2)}`
 }

--- a/src/tersifyAcorn/tersifyAcron.ts
+++ b/src/tersifyAcorn/tersifyAcron.ts
@@ -113,6 +113,7 @@ function tersifyAcornNode(context: TersifyContext, node: AcornNode | null, lengt
       return tersifyMethodDefinition(context, node, length)
     case 'ObjectPattern':
       return tersifyObjectPattern(context, node, length)
+    // istanbul ignore next
     default: {
       const nodeType = (node as any).type
       console.warn(`tersify received unsupported type: ${nodeType}. Please open an issue at https://github.com/unional/tersify/issues

--- a/yarn.lock
+++ b/yarn.lock
@@ -4611,11 +4611,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-iso-error@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/iso-error/-/iso-error-3.1.1.tgz#2b49f3d1cd009a6f6f3c154111e31952cc1d7134"
-  integrity sha512-m8aSCXya61/KUCAXUMYbj/t7HnAKlLeaolT37Ezu6eNFCE2fl+3dyDlpbf0y9DXxY7sZG8zHiV8DkH+V0e3tSw==
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"


### PR DESCRIPTION
fix: fail safe on unsupported node

when encounter not supported value,
it will now emit a warning and continue,
instead of throwing error.

It is more appropriate as this is mostly used as a rendering mechanism.