### PR TITLE
fix: Tersible generic type to unknown

### DIFF
--- a/ts/types.ts
+++ b/ts/types.ts
@@ -7,6 +7,6 @@ export type TersifyOptions = {
   raw?: boolean,
 }
 
-export type Tersible<T = any> = T & {
+export type Tersible<T = unknown> = T & {
   tersify(this: T, options?: Partial<TersifyOptions>): string
 }


### PR DESCRIPTION
When `T=any`, it cause the types to become `any`, as
`= T & {...}`,

making the type not usable.