### PR TITLE
feat: support MetaProperty

### DIFF
--- a/ts/tersify.spec.ts
+++ b/ts/tersify.spec.ts
@@ -2170,3 +2170,9 @@ describe('instance', () => {
     expect(tersify(instance, { maxLength: 18 })).toBe(`TwoProps { va... }`)
   })
 })
+
+it('works with new.target', () => {
+  function meta() { return new.target }
+
+  expect(tersify(meta)).toBe('fn meta() { return new.target }')
+})

--- a/ts/tersifyAcorn/AcornTypes.ts
+++ b/ts/tersifyAcorn/AcornTypes.ts
@@ -11,7 +11,7 @@ export type AcornNode = IdentifierNode | LiteralNode | CallExpressionNode |
   ArrayExpression | ThrowStatementNode | TryStatementNode | CatchClauseNode |
   ThisExpressionNode | ClassExpressionNode | ClassBodyNode | MethodDefinitionNode | SpreadElementNode |
   ObjectPatternNode | SequenceExpression | TemplateLiteral | TemplateElement | TaggedTemplateExpression |
-  ChainExpression
+  ChainExpression | MetaProperty
 
 export interface AcornNodeBase {
   start: number,
@@ -348,4 +348,10 @@ export interface TaggedTemplateExpression extends AcornNodeBase {
 export interface ChainExpression extends AcornNodeBase {
   type: 'ChainExpression',
   expression: MemberExpressionNode | CallExpressionNode
+}
+
+export interface MetaProperty extends AcornNodeBase {
+  type: 'MetaProperty',
+  meta: IdentifierNode,
+  property: IdentifierNode
 }

--- a/ts/tersifyAcorn/tersifyAcorn.ts
+++ b/ts/tersifyAcorn/tersifyAcorn.ts
@@ -15,7 +15,7 @@ import {
   SwitchStatementNode, SymbolForNode, TaggedTemplateExpression, TemplateLiteral,
   ThisExpressionNode, ThrowStatementNode, TryStatementNode, UnaryExpressionNode,
   UpdateExpressionNode, VariableDeclarationNode, VariableDeclaratorNode,
-  WhileStatementNode, YieldExpressionNode
+  WhileStatementNode, YieldExpressionNode, MetaProperty
 } from './AcornTypes.js'
 import { isHigherOperatorOrder } from './isHigherBinaryOperatorOrder.js'
 
@@ -135,11 +135,14 @@ function tersifyAcornNode(context: TersifyContext, node: AcornNode | null, lengt
       return tersifyTaggedTemplateExpression(context, node, length)
     case 'ChainExpression':
       return tersifyChainExpression(context, node, length)
+    case 'MetaProperty':
+      return tersifyMetaProperty(context, node, length)
     // istanbul ignore next
     default:
       return tersifyUnknown(node)
   }
 }
+
 
 // istanbul ignore next
 function tersifyUnknown(node: AcornNode) {
@@ -180,6 +183,10 @@ function tersifyAwaitExpressionNode(context: TersifyContext, node: AwaitExpressi
 function tersifyYieldExpressionNode(context: TersifyContext, node: YieldExpressionNode, length: number) {
   const argument = tersifyAcornNode(context, node.argument, length)
   return `yield ${argument}`
+}
+function tersifyMetaProperty(context: TersifyContext, node: MetaProperty, length: number) {
+  const meta = tersifyAcornNode(context, node.meta, length)
+  return `${meta}.${tersifyAcornNode(context, node.property, length)}`
 }
 
 function tersifyPropertyNode(context: TersifyContext, node: PropertyNode, length: number) {


### PR DESCRIPTION
such as `new.target`

fixes #173 