### PR TITLE
chore: upgrade to pnpm 11.1.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimumreleaseage=1440

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
 		"rimraf": "~6.1.0",
 		"turbo": "^2.3.3"
 	},
-	"packageManager": "pnpm@10.33.4"
+	"packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "packages/*"
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Upgrade pnpm to `11.1.3`
- Add `minimumreleaseage=1440` to `.npmrc` — blocks packages published in the last 24h, reducing supply chain attack risk
- Remove obsolete `use-lockfile-v6` setting (default since pnpm 9)
- Approve native build scripts via `pnpm-workspace.yaml`

## Test plan
- [ ] CI passes