### PR TITLE
ci: release through cyberuni workflows and npm trusted publishing

### DIFF
--- a/.changeset/olive-planets-smoke.md
+++ b/.changeset/olive-planets-smoke.md
@@ -1,0 +1,7 @@
+---
+'tersify': patch
+---
+
+Point package metadata at `cyberuni/tersify` — `repository`, `homepage`, `bugs`, and the
+issue URL printed when an unsupported node type is encountered. `repository` is read when
+generating provenance, so this has to ship before the first trusted-publishing release.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,19 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  merge_group:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
+
+  # The changesets "version packages" PR is the last point where the exact contents of
+  # the next release are both knowable and reviewable. Skipped on every other PR, so it
+  # must never be a required status check.
+  publish-gate:
+    if: startsWith(github.head_ref, 'changeset-release/')
+    uses: cyberuni/.github/.github/workflows/pnpm-publish-gate.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,14 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
     with:
       os: '["ubuntu-latest"]'
 
   release:
-    uses: unional/.github/.github/workflows/pnpm-release-changeset.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
     needs: code
-    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write

--- a/packages/tersify/CHANGELOG.md
+++ b/packages/tersify/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @repobuddy/tersify
+# tersify
 
 ## 4.0.1
 

--- a/packages/tersify/package.json
+++ b/packages/tersify/package.json
@@ -2,13 +2,13 @@
 	"name": "tersify",
 	"version": "4.0.1",
 	"description": "Creates a terse representation of code",
-	"homepage": "https://github.com/unional/tersify/tree/main/packages/tersify",
+	"homepage": "https://github.com/cyberuni/tersify/tree/main/packages/tersify",
 	"bugs": {
-		"url": "https://github.com/unional/tersify/issues"
+		"url": "https://github.com/cyberuni/tersify/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/unional/tersify.git",
+		"url": "https://github.com/cyberuni/tersify.git",
 		"directory": "packages/tersify"
 	},
 	"license": "MIT",

--- a/packages/tersify/readme.md
+++ b/packages/tersify/readme.md
@@ -6,7 +6,7 @@
 [![GitHub NodeJS][github-nodejs]][github-action-url]
 [![Codecov][codecov-image]][codecov-url]
 
-[![Semantic Release][semantic-release-image]][semantic-release-url]
+[![Changesets][changesets-image]][changesets-url]
 
 [![Visual Studio Code][vscode-image]][vscode-url]
 
@@ -84,15 +84,15 @@ boo.a = 3
 boo.tersify() // '{ a: 3 }'
 ```
 
-[codecov-image]: https://codecov.io/gh/unional/tersify/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/tersify
+[changesets-image]: https://img.shields.io/badge/maintained%20with-changesets-176de3.svg
+[changesets-url]: https://github.com/changesets/changesets
+[codecov-image]: https://codecov.io/gh/cyberuni/tersify/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/cyberuni/tersify
 [downloads-image]: https://img.shields.io/npm/dm/tersify.svg?style=flat
 [downloads-url]: https://npmjs.org/package/tersify
-[github-nodejs]: https://github.com/unional/tersify/workflows/nodejs/badge.svg
-[github-action-url]: https://github.com/unional/tersify/actions
+[github-nodejs]: https://github.com/cyberuni/tersify/actions/workflows/release.yml/badge.svg
+[github-action-url]: https://github.com/cyberuni/tersify/actions
 [npm-image]: https://img.shields.io/npm/v/tersify.svg?style=flat
 [npm-url]: https://npmjs.org/package/tersify
-[semantic-release-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
-[semantic-release-url]: https://github.com/semantic-release/semantic-release
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg
 [vscode-url]: https://code.visualstudio.com/

--- a/packages/tersify/src/tersifyAcorn/tersifyAcorn.ts
+++ b/packages/tersify/src/tersifyAcorn/tersifyAcorn.ts
@@ -194,7 +194,7 @@ function tersifyAcornNode(context: TersifyAcornContext, node: AcornNode | null, 
 // istanbul ignore next
 function tersifyUnknown(node: AcornNode, rawString: string) {
 	const nodeType = node.type
-	console.warn(`tersify received unsupported type: ${nodeType}. Please open an issue at https://github.com/unional/tersify/issues
+	console.warn(`tersify received unsupported type: ${nodeType}. Please open an issue at https://github.com/cyberuni/tersify/issues
 node detail:
 ${JSON.stringify(node, undefined, 2)}
 


### PR DESCRIPTION
Phase A of the modernization sweep for `tersify`. **Do not merge yet** — this PR is deliberately
written against the world *after* the repo moves to the `cyberuni` org, which has not happened.
It lands in Phase C, after the transfer and the `npm trust` registration for `tersify`.

## What this changes

### Workflows — both jobs now call cyberuni

| | before | after |
| --- | --- | --- |
| `pull-request.yml` `code` | `unional/.github/…/pnpm-verify.yml` | `cyberuni/.github/…/pnpm-verify.yml` |
| `release.yml` `code` | `unional/.github/…/pnpm-verify.yml` | `cyberuni/.github/…/pnpm-verify.yml` |
| `release.yml` `release` | `pnpm-release-changeset.yml` + `secrets: inherit` | `pnpm-release-changeset-oidc.yml` + explicit `permissions:` |

`grep -rn "unional/.github" .github/workflows/` now returns nothing.

- The release publishes through **npm trusted publishing (OIDC)** instead of `NPM_TOKEN`, and
  pushes the version PR with `GITHUB_TOKEN` instead of `CI_GITHUB_TOKEN`. Both secrets stay in
  place until a publish has proven OIDC works.
- The release caller declares its own `permissions:` block (`id-token`/`contents`/`pull-requests`),
  so the repo's Actions default can be lowered to `read` **after** this lands — not before.
- `pull-request.yml` gains `merge_group:` so a merge queue can be added once the repo is org-owned.
- `pull-request.yml` gains the changesets **publish gate**, which diffs the tarball contents and
  runtime dependencies against the published version on the "version packages" PR. It is skipped on
  every other PR, so it is deliberately *not* a required status check.

**`skip-playwright` is deliberately not set.** `packages/tersify` runs its Storybook stories as a
real chromium browser project under vitest (`vitest.config.ts` → project `storybook`,
`@vitest/browser-playwright`). Verified locally: without a browser installed, `vitest run --coverage`
fails with `browserType.launch: Executable doesn't exist`. Skipping the playwright install would
turn CI red.

`os` stays pinned to `["ubuntu-latest"]`; codecov upload stays on (it feeds the badge and gates
nothing).

### Metadata — post-transfer URLs

`packages/tersify/package.json` `repository` / `homepage` / `bugs`, the readme badges, and the
issue URL printed for an unsupported AST node all point at `cyberuni/tersify`. `repository` is read
when generating provenance, so it has to be right before the first OIDC publish.

The npm package name is unchanged — the npm scope does not follow the GitHub org.

Also fixed while in there: the readme's GitHub Actions badge pointed at a `nodejs` workflow that no
longer exists, the codecov badge pointed at `branch/master`, and a `semantic-release` badge remained
on a repo that has used changesets for some time. `packages/tersify/CHANGELOG.md`'s H1 said
`@repobuddy/tersify`; corrected to `tersify` (changesets inserts immediately after that heading).

### Changeset

A deliberate `patch`. The metadata change is what ships, and without a changeset the release run
goes green and publishes nothing — which would leave Phase C with no version bump to prove
publication with.

## What was already broken

`pull-request` CI was red before this branch existed, on
`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — 9 lockfile entries younger than the `minimumreleaseage=1440`
soak in `.npmrc`, so pnpm rejected its own lockfile (run 30927709523, 2026-08-04, PR #441).

**It has since self-healed and needed no fix here.** The soak is time-relative, so the offending
entries aged past 24h; run 31326616766 on 2026-08-09 passed, and `pnpm install --frozen-lockfile`
against `main` locally reports `✓ Lockfile passes supply-chain policies (779 entries)`. No lockfile
was regenerated and no soak was bypassed.

`package.json` `version` (4.0.1) already matches what is on the registry (4.0.1) — no placeholder.

## Settings applied outside this PR

- Ruleset `main` reconciled to the current baseline: requires **`code / all-checks`** only (the
  `CodeQL` status-check context was replaced by the proper `code_scanning` rule),
  `strict_required_status_checks_policy: true`, `deletion` + `non_fast_forward`. No
  `required_linear_history`, so merge commits are allowed.
- Merge settings: merge commit **on**, squash and rebase **off**, `PR_TITLE`/`PR_BODY`.
- Secret scanning and push protection enabled.
- `default_workflow_permissions` left at `write` on purpose — the `permissions:` block that makes
  `read` safe is in this unmerged PR.
- `can_approve_pull_request_reviews` was already `true`, which is what changesets needs to open the
  version PR. There is no `pull_request` review rule, so the "approve" half grants nothing.

## Not done here

No transfer, no `npm trust` registration, no secret deletion, no auto-merge, no dependency or
toolchain modernization.
